### PR TITLE
Update regex to be less greedy

### DIFF
--- a/src/components/performHighlight.ts
+++ b/src/components/performHighlight.ts
@@ -155,7 +155,7 @@ export function performHighlight(input: string, work: HighlightSet): string {
 
 function swapForTooltip(input: string, tooltip: string, words: string[]) {
     words.forEach((e) => {
-        const regex = new RegExp(`(${e})`, "gi");
+        const regex = new RegExp(`\\b(${e})\\b`, "gi");
         //console.log("Regex: ", regex);
         input = input.replace(regex, `[${tooltip}]$1[/${tooltip}]`);
     });


### PR DESCRIPTION
Fixes: #1 This updates the regex to use the word boundary (\b) to limit the greediness of the regex.  Now when a keyword, such as "cone", is used is will match only on that and not on a word that contains the keyword, such as coney.